### PR TITLE
gh-17909 test suggestion

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -906,6 +906,7 @@ class betaprime_gen(rv_continuous):
             f2=lambda x_, a_, b_: beta._cdf(x_/(1+x_), a_, b_))
 
     def _ppf(self, p, a, b):
+        p, a, b = np.broadcast_arrays(p, a, b)
         # by default, compute compute the ppf by solving the following:
         # p = beta._cdf(x/(1+x), a, b). This implies x = r/(1-r) with
         # r = beta._ppf(p, a, b). This can cause numerical issues if r is

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -3632,32 +3632,6 @@ class TestBeta:
 
 
 class TestBetaPrime:
-    # the test values are used in test_cdf_gh_17631 / test_ppf_gh_17631
-    # They are computed with mpmath. Example:
-    # from mpmath import mp
-    # mp.dps = 50
-    # a, b = mp.mpf(0.05), mp.mpf(0.1)
-    # x = mp.mpf(1e22)
-    # float(mp.betainc(a, b, 0.0, x/(1+x), regularized=True))
-    # we only list the values where rtol=1e-14 can be achieved for both
-    # the cdf and ppf. additional test cases with different tolerances
-    # can be added in test_cdf_gh_17631 / test_ppf_gh_17631
-    cdf_vals = [
-        (1e22, 100.0, 0.05, 0.8973027435427167, 1e-14),
-        (1e10, 0.05, 0.1, 0.9664184367890859, 1e-14),
-        (1e10, 100.0, 0.05, 0.5911548582766262, 1e-14),
-        (1e8, 0.05, 0.1, 0.9467768090820048, 1e-14),
-        (1e8, 100.0, 0.05, 0.4852944858726726, 1e-14),
-        (1e-10, 0.05, 0.1, 0.21238845427095, 1e-14),
-        (1e-10, 1.5, 1.5, 1.697652726007973e-15, 1e-14),
-        (1e-10, 0.05, 100.0, 0.40884514172337383, 1e-14),
-        (1e-22, 0.05, 0.1, 0.053349567649287326, 1e-14),
-        (1e-22, 1.5, 1.5, 1.6976527263135503e-33, 1e-14),
-        (1e-22, 0.05, 100.0, 0.10269725645728331, 1e-14),
-        (1e-100, 0.05, 0.1, 6.7163126421919795e-06, 1e-14),
-        (1e-100, 1.5, 1.5, 1.6976527263135503e-150, 1e-14),
-        (1e-100, 0.05, 100.0, 1.2928818587561651e-05, 1e-14),
-    ]
 
     def test_logpdf(self):
         alpha, beta = 267, 1472
@@ -3709,26 +3683,43 @@ class TestBetaPrime:
         x = stats.betaprime.ppf(p, a, b)
         assert_allclose(x, expected, rtol=1e-14)
 
-    @pytest.mark.parametrize(
-        'x, a, b, p, tol',
-        cdf_vals + [
-            (1e22, 0.05, 0.1, 0.9978811466052919, 1e-12),
-            (1e22, 10, 0.01, 0.38019826239901977, 1e-13),
-            (1e8, 1.5, 1.5, 0.9999999999983024, 1e-5),
-            (1e50, 0.05, 0.1, 0.9999966641709545, 1e-1),
-            (1e50, 100.0, 0.05, 0.995925162631006, 1e-1),]
-    )
-    def test_ppf_gh_17631(self, x, a, b, p, tol):
-        assert_allclose(stats.betaprime.ppf(p, a, b), x, rtol=tol)
+    # the test values are used in test_cdf_gh_17631 / test_ppf_gh_17631
+    # They are computed with mpmath. Example:
+    # from mpmath import mp
+    # mp.dps = 50
+    # a, b = mp.mpf(0.05), mp.mpf(0.1)
+    # x = mp.mpf(1e22)
+    # float(mp.betainc(a, b, 0.0, x/(1+x), regularized=True))
+    # we only list the values where rtol=1e-14 can be achieved for both
+    # the cdf and ppf. additional test cases with different tolerances
+    # can be added in test_cdf_gh_17631 / test_ppf_gh_17631
+    cdf_vals = [
+        (1e22, 0.05, 0.1, 0.9978811466052919),
+        (1e22, 100.0, 0.05, 0.8973027435427167),
+        (1e10, 0.05, 0.1, 0.9664184367890859),
+        (1e10, 1.5, 1.5, 0.9999999999999983),
+        (1e10, 100.0, 0.05, 0.5911548582766262),
+        (1e-10, 0.05, 0.1, 0.21238845427095),
+        (1e-10, 1.5, 1.5, 1.697652726007973e-15),
+        (1e-10, 0.05, 100.0, 0.40884514172337383),
+        (1e-22, 0.05, 0.1, 0.053349567649287326),
+        (1e-22, 1.5, 1.5, 1.6976527263135503e-33),
+        (1e-22, 0.05, 100.0, 0.10269725645728331),
+        (1e-100, 0.05, 0.1, 6.7163126421919795e-06),
+        (1e-100, 1.5, 1.5, 1.6976527263135503e-150),
+        (1e-100, 0.05, 100.0, 1.2928818587561651e-05)]
 
-    @pytest.mark.parametrize(
-        'x, a, b, expected, tol',
-        cdf_vals + [
-            (1e10, 1.5, 1.5, 0.9999999999999983, 1e-14),
-            (1e22, 0.05, 0.1, 0.9978811466052919, 1e-14),
-        ])
-    def test_cdf_gh_17631(self, x, a, b, expected, tol):
-        assert_allclose(stats.betaprime.cdf(x, a, b), expected, rtol=tol)
+    @pytest.mark.parametrize('x, a, b, p', cdf_vals)
+    def test_ppf_gh_17631(self, x, a, b, p):
+        if p > 0.99:
+            pytest.skip(reason='Test cases were generated for CDF, not PPF')
+            # So these rounded, double-precision representations of `p` cannot
+            # be expected to map exactly back to the original `x`
+        assert_allclose(stats.betaprime.ppf(p, a, b), x, rtol=1e-14)
+
+    @pytest.mark.parametrize('x, a, b, p', cdf_vals)
+    def test_cdf_gh_17631(self, x, a, b, p):
+        assert_allclose(stats.betaprime.cdf(x, a, b), p, rtol=1e-14)
 
     @pytest.mark.parametrize(
         'x, a, b, expected',

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -3711,7 +3711,7 @@ class TestBetaPrime:
 
     @pytest.mark.parametrize('x, a, b, p', cdf_vals)
     def test_ppf_gh_17631(self, x, a, b, p):
-        if p > 0.99:
+        if p > 0.95:
             pytest.skip(reason='Test cases were generated for CDF, not PPF')
             # So these rounded, double-precision representations of `p` cannot
             # be expected to map exactly back to the original `x`


### PR DESCRIPTION
Re: gh-17909. I don't know that all the special cases for CDF and PPF add much value because they are simply tuning the tolerances so that the tests pass. The original CDF list has already been checked, so why not just use it verbatim? It's a lot simpler if we acknowledge the reason why the tests don't pass rather than tuning all the tolerances to the tests.